### PR TITLE
Update Tools.pm to support UTF-8 encoding

### DIFF
--- a/src/PVE/Tools.pm
+++ b/src/PVE/Tools.pm
@@ -3,6 +3,10 @@ package PVE::Tools;
 use strict;
 use warnings;
 
+use open qw(:std :utf8);
+use Encode qw(decode_utf8);
+@ARGV = map { decode_utf8($_, 1) } @ARGV;
+
 use Date::Format qw(time2str);
 use Digest::MD5;
 use Digest::SHA;


### PR DESCRIPTION
Fix UTF-8 encoding/decoding issues.

I would suggest adding a line `export PERL_UNICODE=SDA` into `/etc/profile` instead.

Related links:

https://devtut.github.io/perl/file-i-o-reading-and-writing-files.html

https://www.perl.com/pub/2012/05/perlunicook-make-all-io-default-to-utf-8.html/

Related issues:

https://lore.proxmox.com/pve-devel/42ea1a54-f553-4f5a-9892-722b1ad25058@proxmox.com/T/

https://bugzilla.proxmox.com/show_bug.cgi?id=5747

https://bugzilla.proxmox.com/show_bug.cgi?id=1909